### PR TITLE
Add `AdSettings`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -190,6 +190,8 @@ Sets current SDK log level.
 AdSettings.setLogLevel('none' | 'debug' | 'verbose' | 'warning' | 'error' | 'notification');
 ```
 
+**Note:** This method is a noop on Android.
+
 #### setIsChildDirected
 
 Configures the ad control for treatment as child-directed.

--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,8 @@ Features:
     - [NativeAdsManager](#nativeadsmanager)
       - [disableAutoRefresh](#disableautorefresh)
       - [setMediaCachePolicy](#setmediacachepolicy)
+    - [AdSettings](#adsettings)
+      - [addTestDevice](#addtestdevice)
 - [Running example](#running-example)
    - [Install dependencies](#1-install-dependencies)
    - [Start packager](#2-start-packager)
@@ -144,6 +146,26 @@ adsManager.setMediaCachePolicy('none' | 'icon' | 'image' | 'all');
 ```
 
 **Note:** This method is a noop on Android
+
+### AdSettings
+
+```js
+import { AdSettings } from 'react-native-fbads';
+```
+
+AdSettings contains global settings for all ad controls.
+
+#### addTestDevice
+
+Registers given device to receive test ads. When you run app on simulator, it automatically gets added. Use it
+to receive test ads in development mode on a standalone phone. Hash of the current device can be obtained from a
+debug log.
+
+All devices should be specified before any other action takes place, like [`AdsManager`](#nativeadsmanager) gets created.
+
+```js
+AdSettings.addTestDevice('hash');
+```
 
 ## Running example
 

--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,6 @@ Features:
     - [AdSettings](#adsettings)
       - [addTestDevice](#addtestdevice)
       - [clearTestDevices](#cleartestdevices)
-      - [getLogLevel](#getloglevel)
       - [setLogLevel](#setloglevel)
       - [setIsChildDirected](#setischilddirected)
       - [setMediationService](#setmediationservice)
@@ -181,14 +180,6 @@ an instance of AdsManager once again.
 
 ```js
 AdSettings.clearTestDevices();
-```
-
-#### getLogLevel
-
-Returns the current SDK log level
-
-```js
-AdSettings.getLogLevel();
 ```
 
 #### setLogLevel

--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ Features:
       - [setLogLevel](#setloglevel)
       - [setIsChildDirected](#setischilddirected)
       - [setMediationService](#setmediationservice)
-      - [setURLPrefix](#seturlprefix)
+      - [setUrlPrefix](#seturlprefix)
 - [Running example](#running-example)
    - [Install dependencies](#1-install-dependencies)
    - [Start packager](#2-start-packager)

--- a/Readme.md
+++ b/Readme.md
@@ -28,10 +28,17 @@ Features:
       - [setMediaCachePolicy](#setmediacachepolicy)
     - [AdSettings](#adsettings)
       - [addTestDevice](#addtestdevice)
+      - [clearTestDevices](#cleartestdevices)
+      - [getLogLevel](#getloglevel)
+      - [setLogLevel](#setloglevel)
+      - [setIsChildDirected](#setischilddirected)
+      - [setMediationService](#setmediationservice)
+      - [setURLPrefix](#seturlprefix)
 - [Running example](#running-example)
    - [Install dependencies](#1-install-dependencies)
    - [Start packager](#2-start-packager)
    - [Run it on iOS / Android](#3-run-it-on-ios--android)
+- [Credits](#credits)
 
 ## Installation
 
@@ -167,6 +174,57 @@ All devices should be specified before any other action takes place, like [`AdsM
 AdSettings.addTestDevice('hash');
 ```
 
+#### clearTestDevices
+
+Clears all previously set test devices. If you want your ads to respect newly set config, you'll have to destroy and create
+an instance of AdsManager once again.
+
+```js
+AdSettings.clearTestDevices();
+```
+
+#### getLogLevel
+
+Returns the current SDK log level
+
+```js
+AdSettings.getLogLevel();
+```
+
+#### setLogLevel
+
+Sets current SDK log level. 
+
+```js
+AdSettings.setLogLevel('none' | 'debug' | 'verbose' | 'warning' | 'error' | 'notification');
+```
+
+#### setIsChildDirected
+
+Configures the ad control for treatment as child-directed.
+
+```js
+AdSettings.setIsChildDirected(true | false);
+```
+
+#### setMediationService
+
+If an ad provided service is mediating Audience Network in their sdk, it is required to set the name of the mediation service
+
+```js
+AdSettings.setMediationService('foobar');
+```
+
+#### setUrlPrefix
+
+Sets the url prefix to use when making ad requests.
+
+```js
+AdSettings.setUrlPrefix('...');
+```
+
+**Note:** This method should never be used in production
+
 ## Running example
 
 ### 1. Install dependencies
@@ -190,3 +248,7 @@ $ cd ./example && npm start
 $ cd ./example && npm run ios
 $ cd ./examples && npm run android
 ```
+
+### Credits
+
+Some of the API explanations where borrowed from Facebook SDK documentation.

--- a/example/index.js
+++ b/example/index.js
@@ -5,12 +5,7 @@
  */
 
 import React from 'react';
-import {
-  AppRegistry,
-  StyleSheet,
-  Text,
-  View
-} from 'react-native';
+import { AppRegistry, StyleSheet, Text, View } from 'react-native';
 
 import FullAd from './components/FullAd';
 import { NativeAdsManager } from '../';

--- a/src/AdSettings.js
+++ b/src/AdSettings.js
@@ -28,14 +28,7 @@ export default {
   clearTestDevices() {
     CTKAdSettingsManager.clearTestDevices();
   },
-
-  /**
-   * Gets current SDK log level
-   */
-  getLogLevel(): Promise<SDKLogLevel> {
-    return CTKAdSettingsManager.getLogLevel();
-  },
-
+  
   /**
    * Sets current SDK log level
    */

--- a/src/AdSettings.js
+++ b/src/AdSettings.js
@@ -12,11 +12,55 @@ import { NativeModules } from 'react-native';
 
 const { CTKAdSettingsManager } = NativeModules;
 
+type SDKLogLevel = 'none' | 'debug' | 'verbose' | 'warning' | 'error' | 'notification';
+
 export default {
   /**
    * Registers given device with `deviceHash` to receive test Facebook ads.
    */
   addTestDevice(deviceHash: string) {
     CTKAdSettingsManager.addTestDevice(deviceHash);
+  },
+
+  /**
+   * Clears previously set test devices
+   */
+  clearTestDevices() {
+    CTKAdSettingsManager.clearTestDevices();
+  },
+
+  /**
+   * Gets current SDK log level
+   */
+  getLogLevel(): Promise<SDKLogLevel> {
+    return CTKAdSettingsManager.getLogLevel();
+  },
+
+  /**
+   * Sets current SDK log level
+   */
+  setLogLevel(logLevel: SDKLogLevel) {
+    CTKAdSettingsManager.setLogLevel(logLevel);
+  },
+
+  /**
+   * Specifies whether ads are treated as child-directed
+   */
+  setIsChildDirected(isDirected: boolean) {
+    CTKAdSettingsManager.setIsChildDirected(isDirected);
+  },
+
+  /**
+   * Sets mediation service name
+   */
+  setMediationService(mediationService: string) {
+    CTKAdSettingsManager.setMediationService(mediationService);
+  },
+
+  /**
+   * Sets URL prefix
+   */
+  setURLPrefix(urlPrefix: string) {
+    CTKAdSettingsManager.setURLPrefix(urlPrefix);
   },
 };

--- a/src/AdSettings.js
+++ b/src/AdSettings.js
@@ -1,0 +1,22 @@
+/**
+ * AdSettings.js
+ * react-native-fbads
+ *
+ * Created by Mike Grabowski on 29/09/16.
+ * Copyright © 2016 Callstack.io. All rights reserved.
+ *
+ * @flow
+ */
+
+import { NativeModules } from 'react-native';
+
+const { CTKAdSettingsManager } = NativeModules;
+
+export default {
+  /**
+   * Registers given device with `deviceHash` to receive test Facebook ads.
+   */
+  addTestDevice(deviceHash: string) {
+    CTKAdSettingsManager.addTestDevice(deviceHash);
+  },
+};

--- a/src/AdSettings.js
+++ b/src/AdSettings.js
@@ -28,7 +28,7 @@ export default {
   clearTestDevices() {
     CTKAdSettingsManager.clearTestDevices();
   },
-  
+
   /**
    * Sets current SDK log level
    */
@@ -53,7 +53,7 @@ export default {
   /**
    * Sets URL prefix
    */
-  setURLPrefix(urlPrefix: string) {
-    CTKAdSettingsManager.setURLPrefix(urlPrefix);
+  setUrlPrefix(urlPrefix: string) {
+    CTKAdSettingsManager.setUrlPrefix(urlPrefix);
   },
 };

--- a/src/android/src/main/java/io/callstack/react/fbads/AdSettingsManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/AdSettingsManager.java
@@ -1,0 +1,56 @@
+/**
+ * AdSettingsManager.java
+ * io.callstack.react.fbads;
+ *
+ * Created by Mike Grabowski on 29/09/16.
+ * Copyright © 2016 Callstack.io. All rights reserved.
+ */
+package io.callstack.react.fbads;
+
+import android.util.Log;
+
+import com.facebook.ads.AdSettings;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+public class AdSettingsManager extends ReactContextBaseJavaModule {
+    public AdSettingsManager(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "CTKAdSettingsManager";
+    }
+
+    @ReactMethod
+    public void addTestDevice(String deviceHash) {
+        AdSettings.addTestDevice(deviceHash);
+    }
+
+    @ReactMethod
+    public void clearTestDevices() {
+        AdSettings.clearTestDevices();
+    }
+
+    @ReactMethod
+    public void setLogLevel(String logLevel) {
+        Log.w("AdSettingsManager", "This method is not supported on Android");
+    }
+
+    @ReactMethod
+    public void setIsChildDirected(boolean isDirected) {
+        AdSettings.setIsChildDirected(isDirected);
+    }
+
+    @ReactMethod
+    public void setMediationService(String mediationService) {
+        AdSettings.setMediationService(mediationService);
+    }
+
+    @ReactMethod
+    public void setUrlPrefix(String urlPrefix) {
+        AdSettings.setUrlPrefix(urlPrefix);
+    }
+}

--- a/src/android/src/main/java/io/callstack/react/fbads/FBAdsPackage.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/FBAdsPackage.java
@@ -24,7 +24,8 @@ public class FBAdsPackage implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Arrays.<NativeModule>asList(
-           new NativeAdManager(reactContext)
+           new NativeAdManager(reactContext),
+           new AdSettingsManager(reactContext)
         );
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,4 +9,5 @@
  */
 
 export { default as withNativeAd } from './withNativeAd';
+export { default as AdSettings } from './AdSettings';
 export { default as NativeAdsManager } from './NativeAdsManager';

--- a/src/ios/CTKAdSettingsManager.h
+++ b/src/ios/CTKAdSettingsManager.h
@@ -1,0 +1,13 @@
+//
+//  CTKAdSettingsManager.h
+//  rn-fbads
+//
+//  Created by Mike Grabowski on 29/09/16.
+//  Copyright © 2016 Callstack.io. All rights reserved.
+//
+
+#import "RCTBridgeModule.h"
+
+@interface CTKAdSettingsManager : NSObject <RCTBridgeModule>
+
+@end

--- a/src/ios/CTKAdSettingsManager.m
+++ b/src/ios/CTKAdSettingsManager.m
@@ -48,7 +48,7 @@ RCT_EXPORT_METHOD(setMediationService:(NSString *)mediationService) {
   [FBAdSettings setMediationService:mediationService];
 }
 
-RCT_EXPORT_METHOD(setURLPrefix:(NSString *)urlPrefix) {
+RCT_EXPORT_METHOD(setUrlPrefix:(NSString *)urlPrefix) {
   [FBAdSettings setUrlPrefix:urlPrefix];
 }
 

--- a/src/ios/CTKAdSettingsManager.m
+++ b/src/ios/CTKAdSettingsManager.m
@@ -36,10 +36,6 @@ RCT_EXPORT_METHOD(clearTestDevices) {
   [FBAdSettings clearTestDevices];
 }
 
-RCT_EXPORT_METHOD(getLogLevel:(RCTPromiseResolveBlock)resolve rejecter:(__unused RCTPromiseRejectBlock)reject) {
-  resolve(@([FBAdSettings getLogLevel]));
-}
-
 RCT_EXPORT_METHOD(setLogLevel:(FBAdLogLevel)logLevel) {
   [FBAdSettings setLogLevel:logLevel];
 }
@@ -52,7 +48,7 @@ RCT_EXPORT_METHOD(setMediationService:(NSString *)mediationService) {
   [FBAdSettings setMediationService:mediationService];
 }
 
-RCT_EXPORT_METHOD(setUrlPrefix:(NSString *)urlPrefix) {
+RCT_EXPORT_METHOD(setURLPrefix:(NSString *)urlPrefix) {
   [FBAdSettings setUrlPrefix:urlPrefix];
 }
 

--- a/src/ios/CTKAdSettingsManager.m
+++ b/src/ios/CTKAdSettingsManager.m
@@ -8,14 +8,53 @@
 
 #import "CTKAdSettingsManager.h"
 #import "RCTUtils.h"
+#import "RCTConvert.h"
 @import FBAudienceNetwork;
+
+@implementation RCTConvert (CTKNativeAdView)
+
+RCT_ENUM_CONVERTER(FBAdLogLevel, (@{
+  @"none": @(FBAdLogLevelNone),
+  @"debug": @(FBAdLogLevelDebug),
+  @"verbose": @(FBAdLogLevelVerbose),
+  @"warning": @(FBAdLogLevelWarning),
+  @"notification": @(FBAdLogLevelNotification),
+  @"error": @(FBAdLogLevelError),
+}), FBAdLogLevelDebug, integerValue)
+
+@end
 
 @implementation CTKAdSettingsManager
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(addTestDevice:(NSString*)deviceHash) {
+RCT_EXPORT_METHOD(addTestDevice:(NSString *)deviceHash) {
   [FBAdSettings addTestDevice:deviceHash];
 }
+
+RCT_EXPORT_METHOD(clearTestDevices) {
+  [FBAdSettings clearTestDevices];
+}
+
+RCT_EXPORT_METHOD(getLogLevel:(RCTPromiseResolveBlock)resolve rejecter:(__unused RCTPromiseRejectBlock)reject) {
+  resolve(@([FBAdSettings getLogLevel]));
+}
+
+RCT_EXPORT_METHOD(setLogLevel:(FBAdLogLevel)logLevel) {
+  [FBAdSettings setLogLevel:logLevel];
+}
+
+RCT_EXPORT_METHOD(setIsChildDirected:(BOOL)isDirected) {
+  [FBAdSettings setIsChildDirected:isDirected];
+}
+
+RCT_EXPORT_METHOD(setMediationService:(NSString *)mediationService) {
+  [FBAdSettings setMediationService:mediationService];
+}
+
+RCT_EXPORT_METHOD(setUrlPrefix:(NSString *)urlPrefix) {
+  [FBAdSettings setUrlPrefix:urlPrefix];
+}
+
 
 @end

--- a/src/ios/CTKAdSettingsManager.m
+++ b/src/ios/CTKAdSettingsManager.m
@@ -1,0 +1,21 @@
+//
+//  CTKAdSettingsManager.m
+//  rn-fbads
+//
+//  Created by Mike Grabowski on 29/09/16.
+//  Copyright © 2016 Callstack.io. All rights reserved.
+//
+
+#import "CTKAdSettingsManager.h"
+#import "RCTUtils.h"
+@import FBAudienceNetwork;
+
+@implementation CTKAdSettingsManager
+
+RCT_EXPORT_MODULE()
+
+RCT_EXPORT_METHOD(addTestDevice:(NSString*)deviceHash) {
+  [FBAdSettings addTestDevice:deviceHash];
+}
+
+@end

--- a/src/ios/rn-fbads.xcodeproj/project.pbxproj
+++ b/src/ios/rn-fbads.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		ADDCECB11D96B85500C511E0 /* CTKNativeAdManager.m in Sources */ = {isa = PBXBuildFile; fileRef = ADDCECB01D96B85500C511E0 /* CTKNativeAdManager.m */; };
 		ADDCECB41D96B85E00C511E0 /* CTKNativeAdView.m in Sources */ = {isa = PBXBuildFile; fileRef = ADDCECB31D96B85E00C511E0 /* CTKNativeAdView.m */; };
+		ADE502341D9C7A3400A44A63 /* CTKAdSettingsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = ADE502331D9C7A3400A44A63 /* CTKAdSettingsManager.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -29,6 +30,8 @@
 		ADDCECB01D96B85500C511E0 /* CTKNativeAdManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTKNativeAdManager.m; sourceTree = "<group>"; };
 		ADDCECB21D96B85E00C511E0 /* CTKNativeAdView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTKNativeAdView.h; sourceTree = "<group>"; };
 		ADDCECB31D96B85E00C511E0 /* CTKNativeAdView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTKNativeAdView.m; sourceTree = "<group>"; };
+		ADE502321D9C7A3400A44A63 /* CTKAdSettingsManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTKAdSettingsManager.h; sourceTree = "<group>"; };
+		ADE502331D9C7A3400A44A63 /* CTKAdSettingsManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTKAdSettingsManager.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -45,6 +48,8 @@
 		ADDCEC9A1D96B7DD00C511E0 = {
 			isa = PBXGroup;
 			children = (
+				ADE502321D9C7A3400A44A63 /* CTKAdSettingsManager.h */,
+				ADE502331D9C7A3400A44A63 /* CTKAdSettingsManager.m */,
 				ADDCECB21D96B85E00C511E0 /* CTKNativeAdView.h */,
 				ADDCECB31D96B85E00C511E0 /* CTKNativeAdView.m */,
 				ADDCECAF1D96B85500C511E0 /* CTKNativeAdManager.h */,
@@ -118,6 +123,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ADDCECB11D96B85500C511E0 /* CTKNativeAdManager.m in Sources */,
+				ADE502341D9C7A3400A44A63 /* CTKAdSettingsManager.m in Sources */,
 				ADDCECB41D96B85E00C511E0 /* CTKNativeAdView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Required for managing behaviour of ads on a real devices. Also required for implementing banner ads soon.

Implemented single method so far.

Full API docs: https://developers.facebook.com/docs/reference/ios/current/class/FBAdSettings/

- [X] iOS
- [x] Android