### PR TITLE
Added missing headers search paths

### DIFF
--- a/src/ios/rn-fbads.xcodeproj/project.pbxproj
+++ b/src/ios/rn-fbads.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
+					"$(SRCROOT)/../../../react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -240,6 +241,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
+					"$(SRCROOT)/../../../react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
I'm not iOS developer but I found adding this paths necessary in case of "normal" project where `react-native-fbads` was installed by `react-native install` and linked by `react-native link`.
