### PR TITLE
Unified addTestDevice - no fill error

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -251,14 +251,13 @@ AdSettings contains global settings for all ad controls.
 
 #### addTestDevice
 
-Registers given device to receive test ads. When you run app on simulator, it automatically gets added. Use it
-to receive test ads in development mode on a standalone phone. Hash of the current device can be obtained from a
-debug log.
+Registers device to receive test ads. When you run app on simulator, it should automatically get added. Use it
+to receive test ads in development mode on a standalone phone.
 
-All devices should be specified before any other action takes place, like [`AdsManager`](#nativeadsmanager) gets created.
+Should be called before any other action takes place, like [`AdsManager`](#nativeadsmanager) gets created.
 
 ```js
-AdSettings.addTestDevice('hash');
+AdSettings.addTestDevice();
 ```
 
 #### clearTestDevices

--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,7 @@ react-native-fbads [![npm version](https://badge.fury.io/js/react-native-fbads.s
     - [InterstitialAdManager](#interstitialadmanager)
       - [showAd](#showad)
     - [AdSettings](#adsettings)
-      - [deviceHashedId](#devicehashedid)
+      - [currentDeviceHashId](#currentdevicehashid)
       - [addTestDevice](#addtestdevice)
       - [clearTestDevices](#cleartestdevices)
       - [setLogLevel](#setloglevel)
@@ -250,15 +250,15 @@ import { AdSettings } from 'react-native-fbads';
 
 AdSettings contains global settings for all ad controls.
 
-#### deviceHashedId
+#### currentDeviceHashId
 
-Constant which contains current device's hashedId.
+Constant which contains current device's hash id.
 
 #### addTestDevice
 
 Registers given device to receive test ads. When you run app on simulator, it should automatically get added. Use it
 to receive test ads in development mode on a standalone phone. Hash of the current device can be obtained from a
-debug log or `AdSettings.deviceHashedId` constant.
+debug log or `AdSettings.currentDeviceHashId` constant.
 
 All devices should be specified before any other action takes place, like [`AdsManager`](#nativeadsmanager) gets created.
 

--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,7 @@ react-native-fbads [![npm version](https://badge.fury.io/js/react-native-fbads.s
     - [InterstitialAdManager](#interstitialadmanager)
       - [showAd](#showad)
     - [AdSettings](#adsettings)
+      - [deviceHashedId](#devicehashedid)
       - [addTestDevice](#addtestdevice)
       - [clearTestDevices](#cleartestdevices)
       - [setLogLevel](#setloglevel)
@@ -249,15 +250,20 @@ import { AdSettings } from 'react-native-fbads';
 
 AdSettings contains global settings for all ad controls.
 
+#### deviceHashedId
+
+Constant which contains current device's hashedId.
+
 #### addTestDevice
 
-Registers device to receive test ads. When you run app on simulator, it should automatically get added. Use it
-to receive test ads in development mode on a standalone phone.
+Registers given device to receive test ads. When you run app on simulator, it should automatically get added. Use it
+to receive test ads in development mode on a standalone phone. Hash of the current device can be obtained from a
+debug log or `AdSettings.deviceHashedId` constant.
 
-Should be called before any other action takes place, like [`AdsManager`](#nativeadsmanager) gets created.
+All devices should be specified before any other action takes place, like [`AdsManager`](#nativeadsmanager) gets created.
 
 ```js
-AdSettings.addTestDevice();
+AdSettings.addTestDevice('hash');
 ```
 
 #### clearTestDevices

--- a/example/index.js
+++ b/example/index.js
@@ -10,7 +10,7 @@ import { AppRegistry, StyleSheet, Text, TouchableOpacity, ScrollView } from 'rea
 import FullAd from './components/FullAd';
 import { NativeAdsManager, InterstitialAdManager, BannerView, AdSettings } from '../';
 
-AdSettings.addTestDevice();
+AdSettings.addTestDevice(AdSettings.deviceHashedId);
 // AdSettings.clearTestDevices();
 const adsManager = new NativeAdsManager('1912255062335197_1912257885668248');
 

--- a/example/index.js
+++ b/example/index.js
@@ -8,8 +8,10 @@ import React from 'react';
 import { AppRegistry, StyleSheet, Text, TouchableOpacity, ScrollView } from 'react-native';
 
 import FullAd from './components/FullAd';
-import { NativeAdsManager, InterstitialAdManager, BannerView } from '../';
+import { NativeAdsManager, InterstitialAdManager, BannerView, AdSettings } from '../';
 
+AdSettings.addTestDevice();
+// AdSettings.clearTestDevices();
 const adsManager = new NativeAdsManager('1912255062335197_1912257885668248');
 
 class MainApp extends React.Component {

--- a/src/AdSettings.js
+++ b/src/AdSettings.js
@@ -18,8 +18,8 @@ export default {
   /**
    * Registers given device with `deviceHash` to receive test Facebook ads.
    */
-  addTestDevice(deviceHash: string) {
-    CTKAdSettingsManager.addTestDevice(deviceHash);
+  addTestDevice() {
+    CTKAdSettingsManager.addTestDevice();
   },
 
   /**

--- a/src/AdSettings.js
+++ b/src/AdSettings.js
@@ -15,11 +15,17 @@ const { CTKAdSettingsManager } = NativeModules;
 type SDKLogLevel = 'none' | 'debug' | 'verbose' | 'warning' | 'error' | 'notification';
 
 export default {
+
+  /**
+   * Contains device `hashedId`
+   */
+  deviceHashedId: CTKAdSettingsManager.deviceHashedId,
+
   /**
    * Registers given device with `deviceHash` to receive test Facebook ads.
    */
-  addTestDevice() {
-    CTKAdSettingsManager.addTestDevice();
+  addTestDevice(deviceHash: string) {
+    CTKAdSettingsManager.addTestDevice(deviceHash);
   },
 
   /**

--- a/src/AdSettings.js
+++ b/src/AdSettings.js
@@ -17,9 +17,9 @@ type SDKLogLevel = 'none' | 'debug' | 'verbose' | 'warning' | 'error' | 'notific
 export default {
 
   /**
-   * Contains device `hashedId`
+   * Contains device `hash id`
    */
-  deviceHashedId: CTKAdSettingsManager.deviceHashedId,
+  currentDeviceHashId: CTKAdSettingsManager.currentDeviceHashId,
 
   /**
    * Registers given device with `deviceHash` to receive test Facebook ads.

--- a/src/android/src/main/java/io/callstack/react/fbads/AdSettingsManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/AdSettingsManager.java
@@ -66,7 +66,7 @@ public class AdSettingsManager extends ReactContextBaseJavaModule {
         SharedPreferences sp = getReactApplicationContext().getSharedPreferences("FBAdPrefs", 0);
         String deviceHashedId = sp.getString("deviceIdHash", null);
 
-        constants.put("deviceHashedId", deviceHashedId);
+        constants.put("currentDeviceHashId", deviceHashedId);
 
         return constants;
     }

--- a/src/android/src/main/java/io/callstack/react/fbads/AdSettingsManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/AdSettingsManager.java
@@ -7,6 +7,8 @@
  */
 package io.callstack.react.fbads;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.util.Log;
 
 import com.facebook.ads.AdSettings;
@@ -15,8 +17,12 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
 public class AdSettingsManager extends ReactContextBaseJavaModule {
+
+    private Context context;
+
     public AdSettingsManager(ReactApplicationContext reactContext) {
         super(reactContext);
+        context = reactContext;
     }
 
     @Override
@@ -25,8 +31,12 @@ public class AdSettingsManager extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void addTestDevice(String deviceHash) {
-        AdSettings.addTestDevice(deviceHash);
+    public void addTestDevice() {
+        SharedPreferences sp = context.getSharedPreferences("FBAdPrefs", 0);
+        String deviceIdHash = sp.getString("deviceIdHash", null);
+        if (deviceIdHash != null) {
+            AdSettings.addTestDevice(deviceIdHash);
+        }
     }
 
     @ReactMethod

--- a/src/android/src/main/java/io/callstack/react/fbads/AdSettingsManager.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/AdSettingsManager.java
@@ -16,13 +16,13 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
-public class AdSettingsManager extends ReactContextBaseJavaModule {
+import java.util.HashMap;
+import java.util.Map;
 
-    private Context context;
+public class AdSettingsManager extends ReactContextBaseJavaModule {
 
     public AdSettingsManager(ReactApplicationContext reactContext) {
         super(reactContext);
-        context = reactContext;
     }
 
     @Override
@@ -31,12 +31,8 @@ public class AdSettingsManager extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void addTestDevice() {
-        SharedPreferences sp = context.getSharedPreferences("FBAdPrefs", 0);
-        String deviceIdHash = sp.getString("deviceIdHash", null);
-        if (deviceIdHash != null) {
-            AdSettings.addTestDevice(deviceIdHash);
-        }
+    public void addTestDevice(String deviceHashedId) {
+        AdSettings.addTestDevice(deviceHashedId);
     }
 
     @ReactMethod
@@ -62,5 +58,16 @@ public class AdSettingsManager extends ReactContextBaseJavaModule {
     @ReactMethod
     public void setUrlPrefix(String urlPrefix) {
         AdSettings.setUrlPrefix(urlPrefix);
+    }
+
+    @Override
+    public Map<String, Object> getConstants() {
+        final Map<String, Object> constants = new HashMap<>();
+        SharedPreferences sp = getReactApplicationContext().getSharedPreferences("FBAdPrefs", 0);
+        String deviceHashedId = sp.getString("deviceIdHash", null);
+
+        constants.put("deviceHashedId", deviceHashedId);
+
+        return constants;
     }
 }

--- a/src/ios/CTKAdSettingsManager.m
+++ b/src/ios/CTKAdSettingsManager.m
@@ -28,8 +28,8 @@ RCT_ENUM_CONVERTER(FBAdLogLevel, (@{
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(addTestDevice) {
-  [FBAdSettings addTestDevice:[FBAdSettings testDeviceHash]];
+RCT_EXPORT_METHOD(addTestDevice:(NSString *)deviceHash) {
+  [FBAdSettings addTestDevice:deviceHash];
 }
 
 RCT_EXPORT_METHOD(clearTestDevices) {
@@ -52,5 +52,9 @@ RCT_EXPORT_METHOD(setUrlPrefix:(NSString *)urlPrefix) {
   [FBAdSettings setUrlPrefix:urlPrefix];
 }
 
+- (NSDictionary *)constantsToExport
+{
+  return @{ @"deviceHashedId": [FBAdSettings testDeviceHash] };
+}
 
 @end

--- a/src/ios/CTKAdSettingsManager.m
+++ b/src/ios/CTKAdSettingsManager.m
@@ -28,8 +28,8 @@ RCT_ENUM_CONVERTER(FBAdLogLevel, (@{
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_METHOD(addTestDevice:(NSString *)deviceHash) {
-  [FBAdSettings addTestDevice:deviceHash];
+RCT_EXPORT_METHOD(addTestDevice) {
+  [FBAdSettings addTestDevice:[FBAdSettings testDeviceHash]];
 }
 
 RCT_EXPORT_METHOD(clearTestDevices) {

--- a/src/ios/CTKAdSettingsManager.m
+++ b/src/ios/CTKAdSettingsManager.m
@@ -54,7 +54,7 @@ RCT_EXPORT_METHOD(setUrlPrefix:(NSString *)urlPrefix) {
 
 - (NSDictionary *)constantsToExport
 {
-  return @{ @"deviceHashedId": [FBAdSettings testDeviceHash] };
+  return @{ @"currentDeviceHashId": [FBAdSettings testDeviceHash] };
 }
 
 @end


### PR DESCRIPTION
This PR resolve #34.
After adding `[FBAdSettings addTestDevice:[FBAdSettings testDeviceHash]];` I eventually was able to display ads on iOS simulator. Previously I always got `1001 no fill` error.
Unfortunately, Android SDK does not have `testDeviceHash` method so I had to check how `AdSettings` works from decompiled code.