### PR TITLE
Remove createJSModules - RN 0.47 compatibility

### DIFF
--- a/src/android/src/main/java/io/callstack/react/fbads/FBAdsPackage.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/FBAdsPackage.java
@@ -30,7 +30,7 @@ public class FBAdsPackage implements ReactPackage {
         );
     }
 
-    @Override
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. This is backwards compatible according to my tests.