### PR TITLE
Remove overriden createJSModules

### DIFF
--- a/src/android/src/main/java/io/callstack/react/fbads/FBAdsPackage.java
+++ b/src/android/src/main/java/io/callstack/react/fbads/FBAdsPackage.java
@@ -31,11 +31,6 @@ public class FBAdsPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(
            new NativeAdViewManager(reactContext),


### PR DESCRIPTION
Since of recently in master the unused createJSModules has been removed and ReactPackage's no longer contain the definition of createJSModules. There for it must be removed in order to not yield a compile error. This is breaking change.