### PR TITLE
sdk version error fixed

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,6 +27,6 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation "com.android.support:recyclerview-v7:${safeExtGet('supportLibVersion', '26.1.0')}"
-    implementation 'com.facebook.android:audience-network-sdk:6.2.+'
+    implementation 'com.facebook.android:audience-network-sdk:6.+'
     implementation 'com.facebook.android:facebook-android-sdk:6.+'
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
It can't show any type of ads with getting the error message:
Error: The SDK version in the ad request is no longer supported for new apps. Please upgrade to the latest version of 
the SDK.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
1. You can't see any ads by current version of react-native-fbads and you can see the error message.
2. after modifying 'implementation 'com.facebook.android:audience-network-sdk:6.2.+' to implementation 'com.facebook.android:audience-network-sdk:6.+'.
3. You can see ads now.