### PR TITLE
Fix path to index in package json to work in expo.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "homepage": "https://github.com/callstack/react-native-fbads",
   "main": "dist/lib/index.js",
+  "react-native": "src/index.ts",
   "typings": "dist/types/index.d.ts",
   "directories": {
     "example": "example"


### PR DESCRIPTION
This PR was created to solve the [issue with dist path with expo](https://github.com/callstack/react-native-fbads/issues/339). 
